### PR TITLE
refactor: clarify student limit action permissions

### DIFF
--- a/client/src/hooks/useStudentLimit.ts
+++ b/client/src/hooks/useStudentLimit.ts
@@ -19,7 +19,11 @@ export interface StudentLimitStatus {
         totalTokens: number;
     };
     limitExceeded: boolean;
-    blockedActions: {
+    /**
+     * Flags indicating which operations the user is currently allowed to
+     * perform. A value of `true` means the action is permitted.
+     */
+    actionPermissions: {
         canActivateStudents: boolean;
         canSendInvites: boolean;
     };
@@ -56,7 +60,7 @@ const fetchStudentLimitStatus = async (): Promise<StudentLimitStatus> => {
                     totalTokens: 0,
                 },
                 limitExceeded: true,
-                blockedActions: {
+                actionPermissions: {
                     canActivateStudents: false,
                     canSendInvites: false,
                 },
@@ -97,7 +101,7 @@ const fetchStudentLimitStatus = async (): Promise<StudentLimitStatus> => {
                         totalTokens: 0,
                     },
                     limitExceeded: true,
-                    blockedActions: {
+                    actionPermissions: {
                         canActivateStudents: false,
                         canSendInvites: false,
                     },
@@ -118,7 +122,7 @@ const fetchStudentLimitStatus = async (): Promise<StudentLimitStatus> => {
                     totalTokens: 0,
                 },
                 limitExceeded: true,
-                blockedActions: {
+                actionPermissions: {
                     canActivateStudents: false,
                     canSendInvites: false,
                 },
@@ -143,7 +147,7 @@ const fetchStudentLimitStatus = async (): Promise<StudentLimitStatus> => {
                     totalTokens: 0,
                 },
                 limitExceeded: true,
-                blockedActions: {
+                actionPermissions: {
                     canActivateStudents: false,
                     canSendInvites: false,
                 },
@@ -178,7 +182,7 @@ const fetchStudentLimitStatus = async (): Promise<StudentLimitStatus> => {
                 totalTokens: 0,
             },
             limitExceeded: true,
-            blockedActions: {
+            actionPermissions: {
                 canActivateStudents: false,
                 canSendInvites: false,
             },
@@ -311,7 +315,7 @@ export const useStudentLimit = () => {
     }, [status]);
 
     const canSendInvites = useCallback((): boolean => {
-        return status?.blockedActions.canSendInvites ?? false;
+        return status?.actionPermissions.canSendInvites ?? false;
     }, [status]);
 
     const getStatusMessage = useCallback((): string => {

--- a/server/services/StudentLimitService.ts
+++ b/server/services/StudentLimitService.ts
@@ -19,7 +19,12 @@ export interface StudentLimitStatus {
         totalTokens: number;
     };
     limitExceeded: boolean;
-    blockedActions: {
+    /**
+     * Indicates which actions the personal trainer is allowed to perform
+     * based on the current quota status. These flags are `true` when the
+     * action is permitted and `false` when it should be blocked.
+     */
+    actionPermissions: {
         canActivateStudents: boolean;
         canSendInvites: boolean;
     };
@@ -122,7 +127,7 @@ export class StudentLimitService {
                     totalTokens: tokenAssignmentStatus.totalTokens,
                 },
                 limitExceeded,
-                blockedActions: {
+                actionPermissions: {
                     canActivateStudents: canActivateStatus.canActivate,
                     canSendInvites: canActivateStatus.canActivate, // Same logic for now
                 },
@@ -148,7 +153,7 @@ export class StudentLimitService {
                     totalTokens: 0,
                 },
                 limitExceeded: true,
-                blockedActions: {
+                actionPermissions: {
                     canActivateStudents: false,
                     canSendInvites: false,
                 },


### PR DESCRIPTION
## Summary
- rename student limit `blockedActions` to `actionPermissions` and document
- update frontend hook to consume new permission flags

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689517b1f94083319f8673fb8b270a05